### PR TITLE
[RFC] Added grumphp

### DIFF
--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -37,7 +37,8 @@ RUN echo "deb http://packages.dotdeb.org squeeze all" >> /etc/apt/sources.list.d
     php5-imagick
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    composer global require hirak/prestissimo
+    composer global require hirak/prestissimo && \
+    composer global require phpro/grumphp
 
 RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 
@@ -69,6 +70,7 @@ ENV ENVIRONMENT dev
 ENV PHP_FPM_USER www-data
 ENV PHP_FPM_PORT 9000
 ENV PHP_ERROR_REPORTING "E_ALL \& ~E_NOTICE \& ~E_STRICT \& ~E_DEPRECATED"
+ENV PATH "$HOME/.composer/vendor/bin:$PATH"
 
 COPY php.ini    /etc/php5/fpm/conf.d/
 COPY php.ini    /etc/php5/cli/conf.d/

--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -31,7 +31,8 @@ RUN \
   php5-imagick
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    composer global require hirak/prestissimo
+    composer global require hirak/prestissimo && \
+    composer global require phpro/grumphp
 
 RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 
@@ -63,6 +64,7 @@ ENV ENVIRONMENT dev
 ENV PHP_FPM_USER www-data
 ENV PHP_FPM_PORT 9000
 ENV PHP_ERROR_REPORTING "E_ALL \& ~E_NOTICE \& ~E_STRICT \& ~E_DEPRECATED"
+ENV PATH "/root/.composer/vendor/bin:$PATH"
 
 COPY php.ini    /etc/php5/fpm/conf.d/
 COPY php.ini    /etc/php5/cli/conf.d/

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -32,7 +32,8 @@ RUN \
   php5-xsl
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    composer global require hirak/prestissimo
+    composer global require hirak/prestissimo && \
+    composer global require phpro/grumphp
 
 RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 
@@ -64,6 +65,7 @@ ENV ENVIRONMENT dev
 ENV PHP_FPM_USER www-data
 ENV PHP_FPM_PORT 9000
 ENV PHP_ERROR_REPORTING "E_ALL \& ~E_NOTICE \& ~E_STRICT \& ~E_DEPRECATED"
+ENV PATH "/root/.composer/vendor/bin:$PATH"
 
 COPY php.ini    /etc/php5/fpm/conf.d/
 COPY php.ini    /etc/php5/cli/conf.d/

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -48,6 +48,7 @@ RUN \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
     composer global require hirak/prestissimo && \
+    composer global require phpro/grumphp && \
     wget http://robo.li/robo.phar && \
     chmod +x robo.phar && mv robo.phar /usr/bin/robo
 
@@ -80,6 +81,7 @@ ENV ENVIRONMENT dev
 ENV PHP_FPM_USER www-data
 ENV PHP_FPM_PORT 9000
 ENV PHP_ERROR_REPORTING "E_ALL \& ~E_NOTICE \& ~E_STRICT \& ~E_DEPRECATED"
+ENV PATH "/root/.composer/vendor/bin:$PATH"
 
 COPY php.ini    /etc/php/7.0/fpm/conf.d/
 COPY php.ini    /etc/php/7.0/cli/conf.d/


### PR DESCRIPTION
Had to run grumphp on a vendor within a container, the actual project does not have grumphp (yet) so it needs to be in the project composer file first before I can continue. This isn't always possible or requires more work than you predicted.

Also in the case of hooks, it no longer matters where the bin folder is located since it's available globally.
