### PR TITLE
Add php7.2

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,0 +1,94 @@
+FROM debian:jessie
+
+RUN \
+  apt-get update && \
+  apt-get install -y \
+  curl \
+  wget \
+  apt-transport-https \
+  lsb-release \
+  ca-certificates \
+  git
+
+RUN wget -O- https://packages.sury.org/php/apt.gpg | apt-key add - && \
+    echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
+
+RUN \
+  apt-get update && \
+  apt-get install -y \
+  vim \
+  locales \
+  php7.2-fpm \
+  php7.2-mysql \
+  php7.2-gd \
+  php7.2-imagick \
+  php7.2-dev \
+  php7.2-curl \
+  php7.2-opcache \
+  php7.2-cli \
+  php7.2-sqlite \
+  php7.2-intl \
+  php7.2-tidy \
+  php7.2-imap \
+  php7.2-json \
+  php7.2-pspell \
+  php7.2-recode \
+  php7.2-common \
+  php7.2-sybase \
+  php7.2-sqlite3 \
+  php7.2-bz2 \
+  php7.2-common \
+  php7.2-apcu-bc \
+  php7.2-memcached \
+  php7.2-redis \
+  php7.2-xml \
+  php7.2-shmop \
+  php7.2-mbstring \
+  php7.2-zip \
+  php7.2-soap
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    composer global require hirak/prestissimo && \
+    wget http://robo.li/robo.phar && \
+    chmod +x robo.phar && mv robo.phar /usr/bin/robo
+
+RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
+
+RUN echo 'de_DE ISO-8859-1\n\
+de_DE.UTF-8 UTF-8\n\
+de_DE@euro ISO-8859-15\n\
+en_GB ISO-8859-1\n\
+en_GB.ISO-8859-15 ISO-8859-15\n\
+en_US ISO-8859-1\n\
+en_US.ISO-8859-15 ISO-8859-15\n\
+en_US.UTF-8 UTF-8\n\
+fr_FR ISO-8859-1\n\
+fr_FR.UTF-8 UTF-8\n\
+fr_FR@euro ISO-8859-15\n\
+nl_BE ISO-8859-1\n\
+nl_BE.UTF-8 UTF-8\n\
+nl_BE@euro ISO-8859-15\n\
+nl_NL ISO-8859-1\n\
+nl_NL.UTF-8 UTF-8\n\
+nl_NL@euro ISO-8859-15\n'\
+>> /etc/locale.gen &&  \
+usr/sbin/locale-gen
+
+RUN usermod -u 1000 www-data
+RUN mkdir "/run/php"
+
+ENV ENVIRONMENT dev
+ENV PHP_FPM_USER www-data
+ENV PHP_FPM_PORT 9000
+ENV PHP_ERROR_REPORTING "E_ALL \& ~E_NOTICE \& ~E_STRICT \& ~E_DEPRECATED"
+ENV PATH "/root/.composer/vendor/bin:$PATH"
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+COPY php.ini    /etc/php/7.2/fpm/conf.d/
+COPY php.ini    /etc/php/7.2/cli/conf.d/
+COPY www.conf   /etc/php/7.2/fpm/pool.d/
+ADD  run.sh /run.sh
+
+COPY run.sh /run.sh
+
+ENTRYPOINT ["/bin/bash", "/run.sh"]

--- a/7.2/docker-compose.yml
+++ b/7.2/docker-compose.yml
@@ -1,0 +1,8 @@
+php:
+    build: .
+    working_dir: /var/www/app
+    environment:
+        PHP_FPM_USER: root
+        PHP_FPM_PORT: 9000
+        PHP_ERROR_REPORTING: E_ALL
+        ENVIRONMENT: staging

--- a/7.2/php.ini
+++ b/7.2/php.ini
@@ -1,0 +1,11 @@
+date.timezone = Europe/Brussels
+include_path = ".:/usr/share/php"
+realpath_cache_size = 4096k
+realpath_cache_ttl = 7200
+upload_max_filesize = 40M
+post_max_size = 40M
+apc.enable_cli = 1
+apc.shm_size=32M
+apc.ttl=7200
+apc.enable_cli=1
+phar.readonly = Off

--- a/7.2/run.sh
+++ b/7.2/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+variables=( "PHP_FPM_USER" "PHP_FPM_PORT" "PHP_ERROR_REPORTING" "ENVIRONMENT" )
+
+for var in "${variables[@]}"
+do
+   :
+   sed -i "s|%$var%|${!var}|g" /etc/php/7.2/fpm/pool.d/www.conf
+done
+
+/usr/sbin/php-fpm7.2 --allow-to-run-as-root -c /etc/php/7.2/fpm --nodaemonize

--- a/7.2/www.conf
+++ b/7.2/www.conf
@@ -1,0 +1,32 @@
+[global]
+
+error_log = /proc/self/fd/2
+daemonize = no
+
+[wwww]
+
+listen = 0.0.0.0:%PHP_FPM_PORT%
+
+listen.owner = %PHP_FPM_USER%
+listen.group = %PHP_FPM_USER%
+
+listen.mode = 0666
+
+clear_env = no
+
+pm = ondemand
+pm.max_children = 25
+pm.process_idle_timeout = 10s
+pm.max_requests = 200
+
+chdir = /
+
+user = %PHP_FPM_USER%
+group = %PHP_FPM_USER%
+
+php_flag[log_errors] = True
+php_value[display_errors] = False
+php_value[error_log] = /var/log/error.log
+php_value[memory_limit] = 2048M
+php_value[error_reporting] = %PHP_ERROR_REPORTING%
+env[ENVIRONMENT] = %ENVIRONMENT%

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Eg: `image: yappabe/php:5.6`
 
 The following PHP versions are available:
 
+* PHP 7.2 (jessie stable)
+* PHP 7.1 (jessie stable)
 * PHP 7.0 (jessie stable)
 * PHP 5.6 (jessie stable)
 * PHP 5.4 (wheezy stable)


### PR DESCRIPTION
For now the version shows `PHP 7.2.0RC5 (cli) (built: Oct 27 2017 14:29:37) ( NTS )`.
But I thinks it's a matter of time before `PHP 7.2.0` shows up.