### PR TITLE
Removed bcmath from 5.* versions (already included with fpm)

### DIFF
--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -34,7 +34,6 @@ RUN echo "deb http://packages.dotdeb.org squeeze all" >> /etc/apt/sources.list.d
     php5-imap \
     php5-imagick \
     php5-json \
-    php5-bcmath \
     php5-imagick
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \

--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -28,7 +28,6 @@ RUN \
   php5-imap \
   php5-imagick \
   php5-json \
-  php5-bcmath \
   php5-imagick
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -30,7 +30,6 @@ RUN \
   php5-redis \
   php5-twig \
   php5-imagick \
-  php5-bcmath \
   php5-xsl
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \


### PR DESCRIPTION
Apparently bcmath is included in fpm already