### PR TITLE
Added github actions CI

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,21 @@
+name: Docker Image CI
+
+on: [push, pull_request]
+
+jobs:
+
+  build:
+    name: Testing build ${{ matrix.php_version }}
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php_version: ["5.6", "7.0", "7.1", "7.2", "7.3"]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build PHP ${{ matrix.php_version }}
+      run: docker build ${{ matrix.php_version }}/ --tag php:${{ matrix.php_version }}
+

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -77,7 +77,7 @@ nl_NL@euro ISO-8859-15\n'\
 usr/sbin/locale-gen
 
 RUN usermod -u 1000 www-data
-RUN mkdir "/run/php"
+RUN mkdir -p "/run/php"
 
 ENV ENVIRONMENT dev
 ENV PHP_FPM_USER www-data


### PR DESCRIPTION
This will test the builds of all the PHP versions on pushes and PR's

May be improved, old versions are failing but have been for a while - should we remove them completely? I've excluded the from the tests.

I've also fixed the broken 7.0 build.