### PR TITLE
Updated base image to debian bullseye, removed robo package, added PHP 8.1RC6

### DIFF
--- a/.github/workflows/dockerhubpush.yml
+++ b/.github/workflows/dockerhubpush.yml
@@ -1,0 +1,39 @@
+name: Push images to DockerHub
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php_version: [ "7.1", "7.2", "7.3", "7.4", "8.0", "8.1" ]
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_SECRET }}
+      -
+        name: Build and push ${{ matrix.php_version }}
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.php_version }}/
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_NAMESPACE }}/php:${{ matrix.php_version }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["7.1", "7.2", "7.3", "7.4", "8.0"]
+        php_version: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
 
     steps:
     - uses: actions/checkout@v1

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,21 +1,20 @@
-FROM debian:jessie
+FROM debian:bullseye
 
 RUN \
   apt-get update && \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
   curl \
-  wget \
-  apt-transport-https \
   lsb-release \
   ca-certificates \
-  git
+  git \
+  gnupg2
 
-RUN wget -O- https://packages.sury.org/php/apt.gpg | apt-key add - && \
+RUN apt-key adv --fetch-keys 'https://packages.sury.org/php/apt.gpg' && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 
 RUN \
   apt-get update && \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
   vim \
   locales \
   php7.2-fpm \
@@ -48,10 +47,7 @@ RUN \
   php7.2-bcmath \
   php7.2-soap
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    composer global require hirak/prestissimo && \
-    wget http://robo.li/robo.phar && \
-    chmod +x robo.phar && mv robo.phar /usr/bin/robo
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,16 +1,15 @@
-FROM debian:jessie
+FROM debian:bullseye
 
 RUN \
   apt-get update && \
   apt-get install -y \
   curl \
-  wget \
-  apt-transport-https \
   lsb-release \
   ca-certificates \
-  git
+  git \
+  gnupg2
 
-RUN wget -O- https://packages.sury.org/php/apt.gpg | apt-key add - && \
+RUN apt-key adv --fetch-keys 'https://packages.sury.org/php/apt.gpg' && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 
 RUN \
@@ -48,10 +47,7 @@ RUN \
   php7.3-bcmath \
   php7.3-soap
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    composer global require hirak/prestissimo && \
-    wget http://robo.li/robo.phar && \
-    chmod +x robo.phar && mv robo.phar /usr/bin/robo
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,17 +1,15 @@
-FROM debian:buster
+FROM debian:bullseye
 
 RUN \
   apt-get update && \
   apt-get install -y \
   curl \
-  wget \
-  apt-transport-https \
   lsb-release \
   ca-certificates \
-  gnupg2 \
-  git
+  git \
+  gnupg2
 
-RUN wget -O- https://packages.sury.org/php/apt.gpg | apt-key add - && \
+RUN apt-key adv --fetch-keys 'https://packages.sury.org/php/apt.gpg' && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 
 RUN \
@@ -48,10 +46,7 @@ RUN \
   php7.4-bcmath \
   php7.4-soap
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    composer global require hirak/prestissimo && \
-    wget http://robo.li/robo.phar && \
-    chmod +x robo.phar && mv robo.phar /usr/bin/robo
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,17 +1,15 @@
-FROM debian:buster
+FROM debian:bullseye
 
 RUN \
   apt-get update && \
   apt-get install -y \
   curl \
-  wget \
-  apt-transport-https \
   lsb-release \
   ca-certificates \
   gnupg2 \
   git
 
-RUN wget -O- https://packages.sury.org/php/apt.gpg | apt-key add - && \
+RUN apt-key adv --fetch-keys 'https://packages.sury.org/php/apt.gpg' && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 
 RUN \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -2,51 +2,48 @@ FROM debian:bullseye
 
 RUN \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  apt-get install -y \
   curl \
   lsb-release \
   ca-certificates \
-  git \
-  gnupg2
+  gnupg2 \
+  git
 
 RUN apt-key adv --fetch-keys 'https://packages.sury.org/php/apt.gpg' && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 
 RUN \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  apt-get install -y \
   vim \
   locales \
-  php7.1-fpm \
-  php7.1-mysql \
-  php7.1-gd \
-  php7.1-imagick \
-  php7.1-dev \
-  php7.1-curl \
-  php7.1-opcache \
-  php7.1-cli \
-  php7.1-sqlite \
-  php7.1-intl \
-  php7.1-tidy \
-  php7.1-imap \
-  php7.1-json \
-  php7.1-pspell \
-  php7.1-recode \
-  php7.1-common \
-  php7.1-sybase \
-  php7.1-sqlite3 \
-  php7.1-bz2 \
-  php7.1-mcrypt \
-  php7.1-common \
-  php7.1-apcu-bc \
-  php7.1-memcached \
-  php7.1-redis \
-  php7.1-xml \
-  php7.1-shmop \
-  php7.1-mbstring \
-  php7.1-zip \
-  php7.1-bcmath \
-  php7.1-soap
+  php8.1-fpm \
+  php8.1-mysql \
+  php8.1-gd \
+  php8.1-imagick \
+  php8.1-dev \
+  php8.1-curl \
+  php8.1-opcache \
+  php8.1-cli \
+  php8.1-sqlite \
+  php8.1-intl \
+  php8.1-tidy \
+  php8.1-imap \
+  php8.1-pspell \
+  php8.1-common \
+  php8.1-sybase \
+  php8.1-sqlite3 \
+  php8.1-bz2 \
+  php8.1-common \
+  php8.1-apcu \
+  php8.1-memcached \
+  php8.1-redis \
+  php8.1-xml \
+  php8.1-shmop \
+  php8.1-mbstring \
+  php8.1-zip \
+  php8.1-bcmath \
+  php8.1-soap
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
@@ -82,9 +79,9 @@ ENV PHP_ERROR_REPORTING "E_ALL \& ~E_NOTICE \& ~E_STRICT \& ~E_DEPRECATED"
 ENV PATH "/root/.composer/vendor/bin:$PATH"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
-COPY php.ini    /etc/php/7.1/fpm/conf.d/
-COPY php.ini    /etc/php/7.1/cli/conf.d/
-COPY www.conf   /etc/php/7.1/fpm/pool.d/
+COPY php.ini    /etc/php/8.1/fpm/conf.d/
+COPY php.ini    /etc/php/8.1/cli/conf.d/
+COPY www.conf   /etc/php/8.1/fpm/pool.d/
 ADD  run.sh /run.sh
 
 COPY run.sh /run.sh

--- a/8.1/docker-compose.yml
+++ b/8.1/docker-compose.yml
@@ -1,0 +1,8 @@
+php:
+    build: .
+    working_dir: /var/www/app
+    environment:
+        PHP_FPM_USER: root
+        PHP_FPM_PORT: 9000
+        PHP_ERROR_REPORTING: E_ALL
+        ENVIRONMENT: staging

--- a/8.1/php.ini
+++ b/8.1/php.ini
@@ -1,0 +1,11 @@
+date.timezone = Europe/Brussels
+include_path = ".:/usr/share/php"
+realpath_cache_size = 4096k
+realpath_cache_ttl = 7200
+upload_max_filesize = 40M
+post_max_size = 40M
+apc.enable_cli = 1
+apc.shm_size=32M
+apc.ttl=7200
+apc.enable_cli=1
+phar.readonly = Off

--- a/8.1/run.sh
+++ b/8.1/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+variables=( "PHP_FPM_USER" "PHP_FPM_PORT" "PHP_ERROR_REPORTING" "ENVIRONMENT" )
+
+for var in "${variables[@]}"
+do
+   :
+   sed -i "s|%$var%|${!var}|g" /etc/php/8.1/fpm/pool.d/www.conf
+done
+
+/usr/sbin/php-fpm8.1 --allow-to-run-as-root -c /etc/php/8.1/fpm --nodaemonize

--- a/8.1/www.conf
+++ b/8.1/www.conf
@@ -1,0 +1,32 @@
+[global]
+
+error_log = /proc/self/fd/2
+daemonize = no
+
+[wwww]
+
+listen = 0.0.0.0:%PHP_FPM_PORT%
+
+listen.owner = %PHP_FPM_USER%
+listen.group = %PHP_FPM_USER%
+
+listen.mode = 0666
+
+clear_env = no
+
+pm = ondemand
+pm.max_children = 25
+pm.process_idle_timeout = 10s
+pm.max_requests = 200
+
+chdir = /
+
+user = %PHP_FPM_USER%
+group = %PHP_FPM_USER%
+
+php_flag[log_errors] = True
+php_value[display_errors] = False
+php_value[error_log] = /var/log/error.log
+php_value[memory_limit] = 2048M
+php_value[error_reporting] = %PHP_ERROR_REPORTING%
+env[ENVIRONMENT] = %ENVIRONMENT%

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Eg: `image: yappabe/php:7.4`
 
 The following PHP versions are available:
 
-* PHP 8.0 (buster stable)
-* PHP 7.4 (buster stable)
-* PHP 7.3 (jessie stable)
-* PHP 7.2 (jessie stable)
-* PHP 7.1 (jessie stable)
+* PHP 8.1RC6 (bullseye stable)
+* PHP 8.0 (bullseye stable)
+* PHP 7.4 (bullseye stable)
+* PHP 7.3 (bullseye stable)
+* PHP 7.2 (bullseye stable)
+* PHP 7.1 (bullseye stable)
 
 ## Configurations
 


### PR DESCRIPTION
Updated:

- All images base image to `debian:bullseye`
- README

Added:

- `--no-install-recommends` on `apt-get install`
- PHP 8.1RC6 image
- Github workflow for automated build and push to Docker Hub

Changed:

- Use `apt-key adv --fetch-keys` vs. `wget`

Removed:

- `wget` package
-  `apt-transport-https` (This is a dummy transitional package - https support has been moved into the apt package in 1.5. It can be safely removed)
- `prestissimo` composer global package
- `robo` dependency